### PR TITLE
Issue with creating the new azure automation connection

### DIFF
--- a/copy-AzureRunAs.ps1
+++ b/copy-AzureRunAs.ps1
@@ -60,7 +60,8 @@
 		New-AzureRmAutomationCertificate -ResourceGroupName $targetResourceGroup -AutomationAccountName $targetAutomationAccount -Name $certName -Path $certFile -Exportable -Password $certPassword
 		Write-Output "Import Complete"
 		Write-Output "Creating Connection..."
-		$connectionFieldValues = @{"ApplicationId" = $servicePrincipalConnection.ApplicationId; "TenantId" = $servicePrincipalConnection.TenantId; "CertificateThumbprint" = $thumbprint; "SubscriptionId" = (Get-AzureRmContext).Subscription.Id}
+		$subId = $servicePrincipalConnection.SubscriptionId
+		$connectionFieldValues = @{"ApplicationId" = $servicePrincipalConnection.ApplicationId; "TenantId" = $servicePrincipalConnection.TenantId; "CertificateThumbprint" = $thumbprint; "SubscriptionId" = $subId}
 		New-AzureRmAutomationConnection -ResourceGroupName $targetResourceGroup -AutomationAccountName $targetAutomationAccount -Name $connName -ConnectionTypeName $connType -ConnectionFieldValues $connectionFieldValues
 		Write-Output "Connection Created"
 	} else {


### PR DESCRIPTION
The current script seems to be failing at getting the subscription ID from the parameters of the object returned by Get-AzureRmContext. This is necessary for the creation of the new azure automation connection. This was fixed by just getting this necessary ID straight from a parameter of the service principal connection object.